### PR TITLE
Fix #59 Ignore body margins for some elements

### DIFF
--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -249,6 +249,12 @@ picture {
         margin-left: -0.5rem;
     }
 
+    video {
+        width: calc(100% + 1rem);
+        margin-left: -0.5rem;
+        max-height: 100vh;
+    }
+
     pre {
         width: calc(100% + 1rem);
         margin-left: -0.5rem;

--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -248,4 +248,21 @@ picture {
         width: calc(100% + 1rem);
         margin-left: -0.5rem;
     }
+
+    pre {
+        width: calc(100% + 1rem);
+        margin-left: -0.5rem;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+    }
+
+    pre code {
+        border-left: 0.5rem solid transparent;
+        border-right: 0.5rem solid transparent;
+        box-sizing: content-box;
+        margin-left: -0.5rem;
+        margin-right: -0.5rem;
+        padding-left: 0;
+        padding-right: 0;
+    }
 }

--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -242,3 +242,10 @@ picture {
     display: block;
     text-align: center;
 }
+
+@media (max-width: 50rem) {
+    table {
+        width: calc(100% + 1rem);
+        margin-left: -0.5rem;
+    }
+}

--- a/src/css/mobile.css
+++ b/src/css/mobile.css
@@ -6,6 +6,7 @@ body {
 
 img {
     max-width: 100%;
+    max-height: 100vh;
 }
 
 table {
@@ -232,4 +233,12 @@ dd {
 li {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
+}
+
+picture {
+    width: 100vw;
+    position: relative;
+    left: calc(-50vw + 50%);
+    display: block;
+    text-align: center;
 }

--- a/src/css/themes/bulma.css
+++ b/src/css/themes/bulma.css
@@ -120,6 +120,7 @@ tfoot > tr:nth-child(even) {
 
 code {
     background-color: var(--highlighted-background-color);
+    border-color: var(--highlighted-background-color);
 }
 
 kbd {

--- a/src/index.html
+++ b/src/index.html
@@ -757,6 +757,10 @@ H   H EEEEE LLLLL LLLLL  OOO  ,,    W W   OOO  R   R LLLLL DDDD  !!
                         controls
                         src="https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_30mb.mp4"
                     ></video>
+                    <video
+                        controls
+                        src="https://media.w3.org/2010/05/sintel/trailer.mp4"
+                    ></video>
                 </section>
             </section>
             <section id="embedded-content">

--- a/src/index.html
+++ b/src/index.html
@@ -807,6 +807,30 @@ H   H EEEEE LLLLL LLLLL  OOO  ,,    W W   OOO  R   R LLLLL DDDD  !!
                             alt="Placeholder"
                         />
                     </picture>
+                    <picture>
+                        <source
+                            srcset="https://via.placeholder.com/1440x150"
+                            media="(min-width: 1024px)"
+                        />
+                        <source
+                            srcset="https://via.placeholder.com/1024x150"
+                            media="(min-width: 768px)"
+                        />
+                        <source
+                            srcset="https://via.placeholder.com/768x150"
+                            media="(min-width: 320px)"
+                        />
+                        <img
+                            src="https://via.placeholder.com/320"
+                            alt="Placeholder"
+                        />
+                    </picture>
+                    <picture>
+                        <img
+                            src="https://picsum.photos/1920/1080"
+                            alt="Placeholder"
+                        />
+                    </picture>
                 </section>
             </section>
             <section id="demarcating-edits">


### PR DESCRIPTION
- [x] `<picture>`
- [x] `<table>`
- [x] `<code>` inside `<pre>`
- [x] `<video>` (Firefox on Android creates a small horizontal scroll when you play a video. I think it's a Firefox bug. I have no idea how to hack it.)
- [ ] ~`<figure>`~ can't make it work