### PR TITLE
Add hgroup example

### DIFF
--- a/site/kitchen-sink.html
+++ b/site/kitchen-sink.html
@@ -27,6 +27,9 @@ layout: layout
           <a href="#h1-h6">&lt;h1&gt;–&lt;h6&gt;</a>
         </li>
         <li>
+          <a href="#hgroup">&lt;hgroup&gt;</a>
+        </li>
+        <li>
           <a href="#nav">&lt;nav&gt;</a>
         </li>
         <li>
@@ -291,6 +294,13 @@ layout: layout
     <h4>Example</h4>
     <h5>Example</h5>
     <h6>Example</h6>
+  </section>
+  <section id="hgroup">
+    <h3>&lt;hgroup&gt;</h3>
+    <hgroup>
+      <h1>Example</h1>
+      <p>Supporting text</p>
+    </hgroup>
   </section>
   <section id="nav">
     <h3>&lt;nav&gt;</h3>

--- a/src/index.html
+++ b/src/index.html
@@ -43,6 +43,9 @@
               <a href="#h1-h6">&lt;h1&gt;–&lt;h6&gt;</a>
             </li>
             <li>
+              <a href="#hgroup">&lt;hgroup&gt;</a>
+            </li>
+            <li>
               <a href="#nav">&lt;nav&gt;</a>
             </li>
             <li>
@@ -310,6 +313,13 @@
           <h4>Example</h4>
           <h5>Example</h5>
           <h6>Example</h6>
+        </section>
+        <section id="hgroup">
+          <h3>&lt;hgroup&gt;</h3>
+          <hgroup>
+            <h1>Example</h1>
+            <p>Supporting text</p>
+          </hgroup>
         </section>
         <section id="nav">
           <h3>&lt;nav&gt;</h3>

--- a/src/stories/content-sectioning/hgroup.stories.jsx
+++ b/src/stories/content-sectioning/hgroup.stories.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+export default {
+  title: "Content sectioning/<hgroup>",
+};
+
+export const hgroup = {
+  render: () => (
+    <hgroup>
+      <h1>Example</h1>
+      <p>Supporting text</p>
+    </hgroup>
+  ),
+  name: "<hgroup>",
+};


### PR DESCRIPTION
## Summary

- add an `<hgroup>` example to the kitchen sink source and generated site template
- add the matching Storybook content-sectioning story
- link the new section from the kitchen sink navigation

Closes #332.

## Verification

- `npm test`
- Eleventy production build
- Storybook production build
- desktop and mobile rendering checks, including the new navigation anchor
